### PR TITLE
Update url for cc-nc licence to 4.0

### DIFF
--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -351,7 +351,7 @@ class LicenseOpenGovernment(DefaultLicense):
 
 class LicenseCreativeCommonsNonCommercial(DefaultLicense):
     id = "cc-nc"
-    url = "http://creativecommons.org/licenses/by-nc/2.0/"
+    url = "https://creativecommons.org/licenses/by-nc/4.0/"
 
     @property
     def title(self):


### PR DESCRIPTION
Licence URL was out of date (probably by a few years).

New URL: https://creativecommons.org/licenses/by-nc/4.0